### PR TITLE
Annotate Argon with IsAotCompatible

### DIFF
--- a/src/Argon/Argon.csproj
+++ b/src/Argon/Argon.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net472;net48;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <TargetFrameworks Condition="$(Configuration) == 'DebugNet9'">net9.0</TargetFrameworks>
+
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ProjectDefaults" PrivateAssets="all" />

--- a/src/Argon/Converters/KeyValuePairConverter.cs
+++ b/src/Argon/Converters/KeyValuePairConverter.cs
@@ -7,6 +7,8 @@ namespace Argon;
 /// <summary>
 /// Converts a <see cref="KeyValuePair{TKey,TValue}"/> to and from JSON.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class KeyValuePairConverter :
     JsonConverter
 {

--- a/src/Argon/Converters/StringEnumConverter.cs
+++ b/src/Argon/Converters/StringEnumConverter.cs
@@ -7,6 +7,8 @@ namespace Argon;
 /// <summary>
 /// Converts an <see cref="Enum"/> to and from its name string value.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class StringEnumConverter :
     JsonConverter
 {

--- a/src/Argon/JsonConvert.cs
+++ b/src/Argon/JsonConvert.cs
@@ -383,6 +383,8 @@ public static class JsonConvert
     /// Serializes the specified object to a JSON string.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value) =>
         SerializeObject(value, null, (JsonSerializerSettings?) null);
 
@@ -390,6 +392,8 @@ public static class JsonConvert
     /// Serializes the specified object to a JSON string using formatting.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value, Formatting formatting) =>
         SerializeObject(value, formatting, (JsonSerializerSettings?) null);
 
@@ -397,6 +401,8 @@ public static class JsonConvert
     /// Serializes the specified object to a JSON string using a collection of <see cref="JsonConverter" />.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value, params JsonConverter[] converters)
     {
         JsonSerializerSettings? settings = null;
@@ -412,6 +418,8 @@ public static class JsonConvert
     /// Serializes the specified object to a JSON string using formatting and a collection of <see cref="JsonConverter" />.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value, Formatting formatting, params JsonConverter[] converters)
     {
         JsonSerializerSettings? settings = null;
@@ -431,6 +439,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value, JsonSerializerSettings? settings) =>
         SerializeObject(value, null, settings);
 
@@ -448,6 +458,8 @@ public static class JsonConvert
     /// Specifying the type is optional.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value, Type? type, JsonSerializerSettings? settings)
     {
         var serializer = JsonSerializer.CreateDefault(settings);
@@ -463,6 +475,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value, Formatting formatting, JsonSerializerSettings? settings) =>
         SerializeObject(value, null, formatting, settings);
 
@@ -480,6 +494,8 @@ public static class JsonConvert
     /// Specifying the type is optional.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static string SerializeObject(object? value, Type? type, Formatting formatting, JsonSerializerSettings? settings)
     {
         var serializer = JsonSerializer.CreateDefault(settings);
@@ -511,6 +527,8 @@ public static class JsonConvert
     /// Deserializes the JSON to a .NET object.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object DeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value) =>
@@ -520,6 +538,8 @@ public static class JsonConvert
     /// Deserializes the JSON to a .NET object.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object? TryDeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value) =>
@@ -533,6 +553,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object DeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -547,6 +569,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object? TryDeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -557,6 +581,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object DeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -567,6 +593,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object? TryDeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -577,6 +605,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T DeserializeObject<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value) =>
@@ -586,6 +616,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T? TryDeserializeObject<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value) =>
@@ -600,6 +632,8 @@ public static class JsonConvert
     /// as a parameter.
     /// </typeparam>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T DeserializeAnonymousType<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -615,6 +649,8 @@ public static class JsonConvert
     /// as a parameter.
     /// </typeparam>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T? TryDeserializeAnonymousType<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -634,6 +670,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T DeserializeAnonymousType<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -654,6 +692,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T? TryDeserializeAnonymousType<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -665,6 +705,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type using a collection of <see cref="JsonConverter" />.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T DeserializeObject<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -675,6 +717,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type using a collection of <see cref="JsonConverter" />.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T? TryDeserializeObject<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -689,6 +733,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T DeserializeObject<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -703,6 +749,8 @@ public static class JsonConvert
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static T? TryDeserializeObject<T>(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -713,6 +761,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type using a collection of <see cref="JsonConverter" />.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object DeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -728,6 +778,8 @@ public static class JsonConvert
     /// Deserializes the JSON to the specified .NET type using a collection of <see cref="JsonConverter" />.
     /// </summary>
     [DebuggerStepThrough]
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object? TryDeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -756,6 +808,8 @@ public static class JsonConvert
     /// The <see cref="JsonSerializerSettings" /> used to deserialize the object.
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object DeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,
@@ -778,6 +832,8 @@ public static class JsonConvert
     /// The <see cref="JsonSerializerSettings" /> used to deserialize the object.
     /// If this is <c>null</c>, default serialization settings will be used.
     /// </param>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static object? TryDeserializeObject(
         [StringSyntax(StringSyntaxAttribute.Json)]
         string value,

--- a/src/Argon/JsonSerializer.cs
+++ b/src/Argon/JsonSerializer.cs
@@ -8,6 +8,8 @@ namespace Argon;
 /// Serializes and deserializes objects into and from the JSON format.
 /// The <see cref="JsonSerializer" /> enables you to control how objects are encoded into JSON.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class JsonSerializer
 {
     IContractResolver? contractResolver;

--- a/src/Argon/Linq/JArray.cs
+++ b/src/Argon/Linq/JArray.cs
@@ -145,6 +145,8 @@ public class JArray :
     /// </summary>
     /// <param name="o">The object that will be used to create <see cref="JArray" />.</param>
     /// <returns>A <see cref="JArray" /> with the values of the specified object.</returns>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public new static JArray FromObject(object o) =>
         FromObject(o, JsonSerializer.CreateDefault());
 
@@ -170,6 +172,8 @@ public class JArray :
     /// <summary>
     /// Writes this token to a <see cref="JsonWriter" />.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public override void WriteTo(JsonWriter writer, params JsonConverter[] converters)
     {
         writer.WriteStartArray();

--- a/src/Argon/Linq/JObject.cs
+++ b/src/Argon/Linq/JObject.cs
@@ -321,6 +321,8 @@ public class JObject :
     /// </summary>
     /// <param name="o">The object that will be used to create <see cref="JObject" />.</param>
     /// <returns>A <see cref="JObject" /> with the values of the specified object.</returns>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public new static JObject FromObject(object o) =>
         FromObject(o, JsonSerializer.CreateDefault());
 
@@ -345,6 +347,8 @@ public class JObject :
     /// <summary>
     /// Writes this token to a <see cref="JsonWriter" />.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public override void WriteTo(JsonWriter writer, params JsonConverter[] converters)
     {
         writer.WriteStartObject();
@@ -541,8 +545,19 @@ public class JObject :
     /// <returns>
     /// The <see cref="DynamicMetaObject" /> to bind this object.
     /// </returns>
-    protected override DynamicMetaObject GetMetaObject(Expression parameter) =>
-        new DynamicProxyMetaObject<JObject>(parameter, this, new JObjectDynamicProxy());
+    protected override DynamicMetaObject GetMetaObject(Expression parameter)
+    {
+#if HAVE_COMPONENT_MODEL
+        if (!DynamicIsSupported)
+        {
+            throw new NotSupportedException(DynamicNotSupportedMessage);
+        }
+#endif
+        // Can be disabled because we throw when dynamic is not supported before
+#pragma warning disable IL2026, IL3050
+        return new DynamicProxyMetaObject<JObject>(parameter, this, new JObjectDynamicProxy());
+#pragma warning restore IL2026, IL3050
+    }
 
     class JObjectDynamicProxy :
         DynamicProxy<JObject>

--- a/src/Argon/Linq/JProperty.cs
+++ b/src/Argon/Linq/JProperty.cs
@@ -248,6 +248,8 @@ public class JProperty :
     /// <summary>
     /// Writes this token to a <see cref="JsonWriter" />.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public override void WriteTo(JsonWriter writer, params JsonConverter[] converters)
     {
         writer.WritePropertyName(Name);

--- a/src/Argon/Linq/JValue.cs
+++ b/src/Argon/Linq/JValue.cs
@@ -655,6 +655,8 @@ public class JValue :
     /// Writes this token to a <see cref="JsonWriter" />.
     /// </summary>
     /// <param name="converters">A collection of <see cref="JsonConverter" />s which will be used when writing the token.</param>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public override void WriteTo(JsonWriter writer, params JsonConverter[] converters)
     {
         if (converters is {Length: > 0} && value != null)
@@ -878,9 +880,21 @@ public class JValue :
     /// <returns>
     /// The <see cref="DynamicMetaObject" /> to bind this object.
     /// </returns>
-    protected override DynamicMetaObject GetMetaObject(Expression parameter) =>
-        new DynamicProxyMetaObject<JValue>(parameter, this, new JValueDynamicProxy());
+    protected override DynamicMetaObject GetMetaObject(Expression parameter)
+    {
+#if HAVE_COMPONENT_MODEL
+        if (!DynamicIsSupported)
+        {
+            throw new NotSupportedException(DynamicNotSupportedMessage);
+        }
+#endif
+#pragma warning disable IL2026, IL3050
+        return new DynamicProxyMetaObject<JValue>(parameter, this, new JValueDynamicProxy());
+#pragma warning restore IL2026, IL3050
+    }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     class JValueDynamicProxy :
         DynamicProxy<JValue>
     {
@@ -1065,6 +1079,16 @@ public class JValue :
     DateTime IConvertible.ToDateTime(IFormatProvider? provider) =>
         (DateTime) this;
 
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) =>
-        ToObject(conversionType)!;
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider)
+    {
+#if NET7_0_OR_GREATER
+        if (!SerializationIsSupported)
+        {
+            throw new NotSupportedException(SerializationNotSupportedMessage);
+        }
+#endif
+#pragma warning disable IL2026, IL3050
+        return ToObject(conversionType)!;
+#pragma warning restore IL2026, IL3050
+    }
 }

--- a/src/Argon/NamingStrategy/CamelCasePropertyNamesContractResolver.cs
+++ b/src/Argon/NamingStrategy/CamelCasePropertyNamesContractResolver.cs
@@ -7,6 +7,8 @@ namespace Argon;
 /// <summary>
 /// Resolves member mappings for a type, camel casing property names.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class CamelCasePropertyNamesContractResolver :
     DefaultContractResolver
 {

--- a/src/Argon/Serialization/AttributeCache.cs
+++ b/src/Argon/Serialization/AttributeCache.cs
@@ -2,6 +2,8 @@
 // Use of this source code is governed by The MIT License,
 // as found in the license.md file.
 
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 static class AttributeCache<T> where T : Attribute
 {
     static ThreadSafeStore<ICustomAttributeProvider, T?> TypeAttributeCache = new(JsonTypeReflector.GetAttribute<T>);

--- a/src/Argon/Serialization/DefaultContractResolver.cs
+++ b/src/Argon/Serialization/DefaultContractResolver.cs
@@ -7,6 +7,8 @@ namespace Argon;
 /// <summary>
 /// Used by <see cref="JsonSerializer" /> to resolve a <see cref="JsonContract" /> for a given <see cref="System.Type" />.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class DefaultContractResolver : IContractResolver
 {
     // Json.NET Schema requires a property

--- a/src/Argon/Serialization/DefaultSerializationBinder.cs
+++ b/src/Argon/Serialization/DefaultSerializationBinder.cs
@@ -7,6 +7,8 @@ namespace Argon;
 /// <summary>
 /// The default serialization binder used when resolving and loading classes from type names.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class DefaultSerializationBinder :
     ISerializationBinder
 {

--- a/src/Argon/Serialization/DynamicValueProvider.cs
+++ b/src/Argon/Serialization/DynamicValueProvider.cs
@@ -7,6 +7,7 @@ namespace Argon;
 /// <summary>
 /// Get and set values for a <see cref="MemberInfo" /> using dynamic methods.
 /// </summary>
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class DynamicValueProvider : IValueProvider
 {
     readonly MemberInfo member;

--- a/src/Argon/Serialization/JsonArrayContract.cs
+++ b/src/Argon/Serialization/JsonArrayContract.cs
@@ -24,6 +24,7 @@ public class JsonArrayContract : JsonContainerContract
 
     readonly Type? genericCollectionDefinition;
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     Type? genericWrapperType;
     ObjectConstructor? genericWrapperCreator;
     Func<object>? genericTemporaryCollectionCreator;
@@ -38,6 +39,7 @@ public class JsonArrayContract : JsonContainerContract
 
     internal ObjectConstructor? ParameterizedCreator
     {
+        [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
         get
         {
             if (parameterizedCreator == null &&
@@ -80,6 +82,8 @@ public class JsonArrayContract : JsonContainerContract
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonArrayContract" /> class.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public JsonArrayContract(Type underlyingType)
         : base(underlyingType)
     {
@@ -208,6 +212,7 @@ public class JsonArrayContract : JsonContainerContract
         }
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     internal IWrappedCollection CreateWrapper(object list)
     {
         if (genericWrapperCreator == null)
@@ -235,6 +240,7 @@ public class JsonArrayContract : JsonContainerContract
         return (IWrappedCollection) genericWrapperCreator(list);
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     internal IList CreateTemporaryCollection()
     {
         if (genericTemporaryCollectionCreator == null)

--- a/src/Argon/Serialization/JsonContainerContract.cs
+++ b/src/Argon/Serialization/JsonContainerContract.cs
@@ -35,6 +35,8 @@ public class JsonContainerContract : JsonContract
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonContainerContract" /> class.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     internal JsonContainerContract(Type underlyingType)
         : base(underlyingType)
     {

--- a/src/Argon/Serialization/JsonContract.cs
+++ b/src/Argon/Serialization/JsonContract.cs
@@ -12,6 +12,7 @@ public abstract class JsonContract
     internal bool IsNullable;
     internal bool IsConvertible;
     internal bool IsEnum;
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
     internal Type NonNullableUnderlyingType;
     internal ReadType InternalReadType;
     internal JsonContractType ContractType;
@@ -27,6 +28,7 @@ public abstract class JsonContract
     /// <summary>
     /// Gets or sets the type created during deserialization.
     /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
     public Type CreatedType
     {
         get;
@@ -66,7 +68,9 @@ public abstract class JsonContract
     /// </summary>
     public bool DefaultCreatorNonPublic { get; set; }
 
-    internal JsonContract(Type underlyingType)
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    internal JsonContract(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type underlyingType)
     {
         UnderlyingType = underlyingType;
 

--- a/src/Argon/Serialization/JsonDictionaryContract.cs
+++ b/src/Argon/Serialization/JsonDictionaryContract.cs
@@ -37,6 +37,7 @@ public class JsonDictionaryContract : JsonContainerContract
 
     readonly Type? dictionaryDefinition;
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
     Type? genericWrapperType;
     ObjectConstructor? genericWrapperCreator;
 
@@ -52,6 +53,7 @@ public class JsonDictionaryContract : JsonContainerContract
 
     internal ObjectConstructor? ParameterizedCreator
     {
+        [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
         get
         {
             if (parameterizedCreator == null &&
@@ -81,6 +83,8 @@ public class JsonDictionaryContract : JsonContainerContract
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonDictionaryContract" /> class.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public JsonDictionaryContract(Type underlyingType)
         : base(underlyingType)
     {
@@ -196,6 +200,7 @@ public class JsonDictionaryContract : JsonContainerContract
                definition == typeof(ImmutableSortedDictionary<,>);
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     internal IWrappedDictionary CreateWrapper(object dictionary)
     {
         if (genericWrapperCreator == null)
@@ -209,6 +214,7 @@ public class JsonDictionaryContract : JsonContainerContract
         return (IWrappedDictionary) genericWrapperCreator(dictionary);
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     internal IDictionary CreateTemporaryDictionary()
     {
         if (genericTemporaryDictionaryCreator == null)

--- a/src/Argon/Serialization/JsonDynamicContract.cs
+++ b/src/Argon/Serialization/JsonDynamicContract.cs
@@ -7,6 +7,8 @@ namespace Argon;
 /// <summary>
 /// Contract details for a <see cref="Type" /> used by the <see cref="JsonSerializer" />.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 public class JsonDynamicContract : JsonContainerContract
 {
     /// <summary>

--- a/src/Argon/Serialization/JsonLinqContract.cs
+++ b/src/Argon/Serialization/JsonLinqContract.cs
@@ -7,6 +7,7 @@ namespace Argon;
 /// <summary>
 /// Contract details for a <see cref="Type" /> used by the <see cref="JsonSerializer" />.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
 public class JsonLinqContract : JsonContract
 {
     /// <summary>

--- a/src/Argon/Serialization/JsonObjectContract.cs
+++ b/src/Argon/Serialization/JsonObjectContract.cs
@@ -82,6 +82,8 @@ public class JsonObjectContract : JsonContainerContract
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonObjectContract" /> class.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public JsonObjectContract(Type underlyingType)
         : base(underlyingType)
     {

--- a/src/Argon/Serialization/JsonPrimitiveContract.cs
+++ b/src/Argon/Serialization/JsonPrimitiveContract.cs
@@ -14,6 +14,7 @@ public class JsonPrimitiveContract : JsonContract
     /// <summary>
     /// Initializes a new instance of the <see cref="JsonPrimitiveContract" /> class.
     /// </summary>
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
     public JsonPrimitiveContract(Type underlyingType)
         : base(underlyingType)
     {

--- a/src/Argon/Serialization/JsonProperty.cs
+++ b/src/Argon/Serialization/JsonProperty.cs
@@ -56,6 +56,7 @@ public class JsonProperty(Type propertyType, Type declaringType)
     /// <summary>
     /// Gets or sets the type of the property.
     /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type PropertyType { get; set; } = propertyType;
 
     /// <summary>

--- a/src/Argon/Serialization/JsonSerializerInternalReader.cs
+++ b/src/Argon/Serialization/JsonSerializerInternalReader.cs
@@ -29,6 +29,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
     JsonContract GetContract(Type type) =>
         Serializer.ResolveContract(type);
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public object? Deserialize(JsonReader reader, Type? type, bool? checkAdditionalContent)
     {
         var contract = GetContractSafe(type);
@@ -82,6 +84,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         }
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     JsonSerializerProxy GetInternalSerializer() =>
         InternalSerializer ??= new(this);
 
@@ -155,6 +159,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         throw JsonSerializationException.Create(reader, "Unexpected end when deserializing object.");
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object? CreateValueInternal(JsonReader reader, Type? type, JsonContract? contract, JsonProperty? member, JsonContainerContract? containerContract, JsonProperty? containerMember, object? existingValue)
     {
         if (contract is {ContractType: JsonContractType.Linq})
@@ -283,6 +289,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return null;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object? CreateObject(JsonReader reader, Type? type, JsonContract? contract, JsonProperty? member, JsonContainerContract? containerContract, JsonProperty? containerMember, object? existingValue)
     {
         string? id;
@@ -446,6 +454,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         throw JsonSerializationException.Create(reader, message);
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     bool ReadMetadataPropertiesToken(JTokenReader reader, ref Type? type, ref JsonContract? contract, JsonProperty? member, JsonContainerContract? containerContract, JsonProperty? containerMember, object? existingValue, out object? newValue, out string? id)
     {
         id = null;
@@ -533,6 +543,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return false;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     bool ReadMetadataProperties(JsonReader reader, ref Type? type, ref JsonContract? contract, JsonProperty? member, JsonContainerContract? containerContract, JsonProperty? containerMember, object? existingValue, out object? newValue, out string? id)
     {
         id = null;
@@ -620,6 +632,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return false;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void ResolveTypeName(JsonReader reader, ref Type? type, ref JsonContract? contract, JsonProperty? member, JsonContainerContract? containerContract, JsonProperty? containerMember, string qualifiedTypeName)
     {
         var resolvedTypeNameHandling =
@@ -674,6 +688,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return arrayContract;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object? CreateList(JsonReader reader, Type? type, JsonContract? contract, JsonProperty? member, object? existingValue, string? id)
     {
         if (HasNoDefinedType(contract))
@@ -753,6 +769,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         contract.ContractType == JsonContractType.Linq ||
         contract.UnderlyingType == typeof(IDynamicMetaObjectProvider);
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     static object? EnsureType(JsonReader reader, object? value, CultureInfo culture, JsonContract? contract, Type? targetType)
     {
         if (targetType == null)
@@ -823,6 +841,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return value;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     bool SetPropertyValue(JsonProperty property, JsonConverter? propertyConverter, JsonContainerContract? containerContract, JsonProperty? containerProperty, JsonReader reader, object target)
     {
         var skipSettingProperty = CalculatePropertyDetails(
@@ -1000,6 +1020,7 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return property.Writable;
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     IList CreateNewList(JsonReader reader, JsonArrayContract contract, out bool createdFromNonDefaultCreator)
     {
         // some types like non-generic IEnumerable can be serialized but not deserialized
@@ -1069,6 +1090,7 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         throw JsonSerializationException.Create(reader, $"Could not create an instance of type {contract.UnderlyingType}. Type is an interface or abstract class and cannot be instantiated.");
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     IDictionary CreateNewDictionary(JsonReader reader, JsonDictionaryContract contract, out bool createdFromNonDefaultCreator)
     {
         if (contract.OverrideCreator != null)
@@ -1124,6 +1146,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
     void OnDeserialized(JsonReader reader, object value) =>
         Serializer.Deserialized?.Invoke(reader, value);
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object PopulateDictionary(IDictionary dictionary, JsonReader reader, JsonDictionaryContract contract, JsonProperty? containerProperty, string? id)
     {
         var underlyingDictionary = dictionary is IWrappedDictionary wrappedDictionary ? wrappedDictionary.UnderlyingDictionary : dictionary;
@@ -1258,6 +1282,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return underlyingDictionary;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void PopulateMultidimensionalArray(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty? containerProperty, string? id)
     {
         var rank = contract.UnderlyingType.GetArrayRank();
@@ -1407,6 +1433,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         }
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty? containerProperty, string? id)
     {
 #pragma warning disable CS8600, CS8602, CS8603, CS8604
@@ -1504,6 +1532,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
 #pragma warning restore CS8600, CS8602, CS8603, CS8604
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object CreateDynamic(JsonReader reader, JsonDynamicContract contract, JsonProperty? member, string? id)
     {
         IDynamicMetaObjectProvider newObject;
@@ -1622,6 +1652,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         public bool Used;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object CreateObjectUsingCreatorWithParameters(JsonReader reader, JsonObjectContract contract, JsonProperty? containerProperty, ObjectConstructor creator, string? id)
     {
         // only need to keep a track of properties' presence if they are required or a value should be defaulted if missing
@@ -1835,9 +1867,13 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return createdObject;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object? DeserializeConvertible(JsonConverter converter, JsonReader reader, Type type, object? existingValue) =>
         converter.ReadJson(reader, type, existingValue, GetInternalSerializer());
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     List<CreatorPropertyContext> ResolvePropertyAndCreatorValues(JsonObjectContract contract, JsonProperty? containerProperty, JsonReader reader, Type type)
     {
         var propertyValues = new List<CreatorPropertyContext>();
@@ -1921,6 +1957,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return propertyValues;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public object CreateNewObject(JsonReader reader, JsonObjectContract objectContract, JsonProperty? containerMember, string? id, out bool createdFromNonDefaultCreator)
     {
         object? newObject = null;
@@ -1965,6 +2003,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return newObject;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     object PopulateObject(object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty? member, string? id)
     {
         OnDeserializing(reader, newObject);
@@ -2108,6 +2148,8 @@ class JsonSerializerInternalReader(JsonSerializer serializer) :
         return false;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void EndProcessProperty(object newObject, JsonReader reader, JsonObjectContract contract, int initialDepth, JsonProperty property, PropertyPresence presence, bool setDefaultValue)
     {
         if (presence is not (PropertyPresence.None or PropertyPresence.Null))

--- a/src/Argon/Serialization/JsonSerializerInternalWriter.cs
+++ b/src/Argon/Serialization/JsonSerializerInternalWriter.cs
@@ -12,6 +12,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
     int rootLevel;
     readonly List<object> serializeStack = [];
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public void Serialize(JsonWriter jsonWriter, object? value, Type? type)
     {
         rootType = type;
@@ -53,6 +55,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         }
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     JsonSerializerProxy GetInternalSerializer() =>
         InternalSerializer ??= new(this);
 
@@ -93,6 +97,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         writer.WriteEndObject();
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeValue(JsonWriter writer, object? value, JsonContract? valueContract, JsonProperty? member, JsonContainerContract? containerContract, JsonProperty? containerProperty)
     {
         if (value == null)
@@ -310,6 +316,7 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         }
     }
 
+    [RequiresUnreferencedCode("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
     static bool TryConvertToString(object value, Type type, [NotNullWhen(true)] out string? s)
     {
 #if NET6_0_OR_GREATER
@@ -352,6 +359,7 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         return false;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
     void SerializeString(JsonWriter writer, object value, JsonStringContract contract)
     {
         OnSerializing(writer, value);
@@ -368,6 +376,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
     void OnSerialized(JsonWriter writer, object value) =>
         Serializer.Serialized?.Invoke(writer, value);
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeObject(JsonWriter writer, object value, JsonObjectContract contract, JsonProperty? member, JsonContainerContract? collectionContract, JsonProperty? containerProperty)
     {
         OnSerializing(writer, value);
@@ -508,6 +518,9 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         value != null &&
         (value & flag) == flag;
 
+
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeConvertible(JsonWriter writer, JsonConverter converter, object value, JsonContract contract, JsonContainerContract? collectionContract, JsonProperty? containerProperty)
     {
         if (ShouldWriteReference(value, null, contract, collectionContract, containerProperty))
@@ -528,6 +541,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         serializeStack.RemoveAt(serializeStack.Count - 1);
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeList(JsonWriter writer, IEnumerable values, JsonArrayContract contract, JsonProperty? member, JsonContainerContract? collectionContract, JsonProperty? containerProperty)
     {
         var underlyingList = values is IWrappedCollection wrappedCollection ? wrappedCollection.UnderlyingCollection : values;
@@ -561,6 +576,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         OnSerialized(writer, underlyingList);
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     private void SerializeArrayItem(JsonWriter writer, JsonArrayContract contract, JsonProperty? member, object? value, object underlyingList, int initialDepth, ref int index)
     {
         try
@@ -608,6 +625,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         }
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeMultidimensionalArray(JsonWriter writer, Array values, JsonArrayContract contract, JsonProperty? member, JsonContainerContract? collectionContract, JsonProperty? containerProperty)
     {
         OnSerializing(writer, values);
@@ -628,6 +647,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         OnSerialized(writer, values);
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeMultidimensionalArray(JsonWriter writer, Array values, JsonArrayContract contract, JsonProperty? member, int initialDepth, int[] indices)
     {
         var dimension = indices.Length;
@@ -716,6 +737,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         return writeMetadataObject;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeDynamic(JsonWriter writer, IDynamicMetaObjectProvider value, JsonDynamicContract contract, JsonProperty? member, JsonContainerContract? collectionContract, JsonProperty? containerProperty)
     {
         OnSerializing(writer, value);
@@ -797,6 +820,7 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         OnSerialized(writer, value);
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
     bool ShouldWriteDynamicProperty(object? memberValue)
     {
         if (Serializer.NullValueHandling == NullValueHandling.Ignore &&
@@ -853,6 +877,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         return false;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeDictionary(JsonWriter writer, IDictionary values, JsonDictionaryContract contract, JsonProperty? member, JsonContainerContract? collectionContract, JsonProperty? containerProperty)
     {
 #pragma warning disable CS8600, CS8602, CS8604
@@ -908,6 +934,8 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
 #pragma warning restore CS8600, CS8602, CS8604
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     void SerializeDictionaryItem(JsonWriter writer, JsonDictionaryContract contract, JsonProperty? member, object key, object? value, JsonContract keyContract, object underlyingDictionary)
     {
         var initialDepth = writer.Top;
@@ -980,6 +1008,7 @@ class JsonSerializerInternalWriter(JsonSerializer serializer) :
         }
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
     static string GetDictionaryPropertyName(object key, JsonContract contract, out bool escape)
     {
         if (contract.ContractType == JsonContractType.Primitive)

--- a/src/Argon/Serialization/JsonSerializerProxy.cs
+++ b/src/Argon/Serialization/JsonSerializerProxy.cs
@@ -2,6 +2,8 @@
 // Use of this source code is governed by The MIT License,
 // as found in the license.md file.
 
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 class JsonSerializerProxy : JsonSerializer
 {
     readonly JsonSerializerInternalReader? serializerReader;

--- a/src/Argon/Serialization/JsonStringContract.cs
+++ b/src/Argon/Serialization/JsonStringContract.cs
@@ -7,6 +7,7 @@ namespace Argon;
 /// <summary>
 /// Contract details for a <see cref="Type" /> used by the <see cref="JsonSerializer" />.
 /// </summary>
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
 public class JsonStringContract : JsonPrimitiveContract
 {
     /// <summary>

--- a/src/Argon/Utilities/DelegateFactory.cs
+++ b/src/Argon/Utilities/DelegateFactory.cs
@@ -6,6 +6,7 @@
 
 static class DelegateFactory
 {
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     static DynamicMethod CreateDynamicMethod(string name, Type? returnType, Type[] parameterTypes, Type owner)
     {
         if (owner.IsInterface)
@@ -16,6 +17,7 @@ static class DelegateFactory
         return new(name, returnType, parameterTypes, owner, true);
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static ObjectConstructor CreateParameterizedConstructor(MethodBase method)
     {
         var dynamicMethod = CreateDynamicMethod(method.ToString()!, typeof(object), [typeof(object[])], method.DeclaringType!);
@@ -26,6 +28,7 @@ static class DelegateFactory
         return (ObjectConstructor) dynamicMethod.CreateDelegate(typeof(ObjectConstructor));
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static MethodCall<T, object?> CreateMethodCall<T>(MethodBase method)
     {
         var dynamicMethod = CreateDynamicMethod(method.ToString()!, typeof(object), [typeof(object), typeof(object[])], method.DeclaringType!);
@@ -213,7 +216,9 @@ static class DelegateFactory
         generator.Return();
     }
 
-    public static Func<T> CreateDefaultConstructor<T>(Type type)
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
+    public static Func<T> CreateDefaultConstructor<T>(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type)
     {
         var method = CreateDynamicMethod($"Create{type.FullName}", typeof(T), Type.EmptyTypes, type);
         method.InitLocals = true;
@@ -224,7 +229,10 @@ static class DelegateFactory
         return (Func<T>) method.CreateDelegate(typeof(Func<T>));
     }
 
-    static void GenerateCreateDefaultConstructorIL(Type type, ILGenerator generator, Type delegateType)
+    static void GenerateCreateDefaultConstructorIL(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type,
+        ILGenerator generator,
+        Type delegateType)
     {
         if (type.IsValueType)
         {
@@ -253,6 +261,7 @@ static class DelegateFactory
         generator.Return();
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static Func<T, object?> CreateGet<T>(PropertyInfo property)
     {
         var method = CreateDynamicMethod($"Get{property.Name}", typeof(object), [typeof(T)], property.DeclaringType!);
@@ -283,6 +292,7 @@ static class DelegateFactory
 
     static Type[] objectArray = [typeof(object)];
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static Func<T, object?> CreateGet<T>(FieldInfo field)
     {
         if (field.IsLiteral)
@@ -315,6 +325,7 @@ static class DelegateFactory
         generator.Return();
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static Action<T, object?> CreateSet<T>(FieldInfo field)
     {
         var method = CreateDynamicMethod($"Set{field.Name}", null, [typeof(T), typeof(object)], field.DeclaringType!);
@@ -347,6 +358,7 @@ static class DelegateFactory
         generator.Return();
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static Action<T, object?> CreateSet<T>(PropertyInfo property)
     {
         var method = CreateDynamicMethod($"Set{property.Name}", null, [typeof(T), typeof(object)], property.DeclaringType!);
@@ -371,6 +383,7 @@ static class DelegateFactory
         generator.Return();
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static Func<T, object?> CreateGet<T>(MemberInfo member)
     {
         if (member is PropertyInfo property)
@@ -392,6 +405,7 @@ static class DelegateFactory
         throw new($"Could not create getter for {member}.");
     }
 
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     public static Action<T, object?> CreateSet<T>(MemberInfo member)
     {
         if (member is PropertyInfo property)

--- a/src/Argon/Utilities/DynamicProxyMetaObject.cs
+++ b/src/Argon/Utilities/DynamicProxyMetaObject.cs
@@ -2,6 +2,8 @@
 // Use of this source code is governed by The MIT License,
 // as found in the license.md file.
 
+[RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 sealed class DynamicProxyMetaObject<T> : DynamicMetaObject
 {
     readonly DynamicProxy<T> proxy;
@@ -389,6 +391,7 @@ sealed class DynamicProxyMetaObject<T> : DynamicMetaObject
     // is only used by DynamicObject.GetMember--it is not expected to
     // (and cannot) implement binding semantics. It is just so the DO
     // can use the Name and IgnoreCase properties.
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     sealed class GetBinderAdapter : GetMemberBinder
     {
         internal GetBinderAdapter(InvokeMemberBinder binder) :

--- a/src/Argon/Utilities/DynamicUtils.cs
+++ b/src/Argon/Utilities/DynamicUtils.cs
@@ -19,6 +19,8 @@ static class DynamicUtils
         static MethodCall<object?, object?>? setMemberCall;
         static bool init;
 
+        [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+        [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
         static void Init()
         {
             if (init)
@@ -41,6 +43,7 @@ static class DynamicUtils
             init = true;
         }
 
+        [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
         static object CreateSharpArgumentInfoArray(params int[] values)
         {
             var csharpArgumentInfoType = Type.GetType(CSharpArgumentInfoTypeName)!;
@@ -58,6 +61,8 @@ static class DynamicUtils
             return a;
         }
 
+        [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+        [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
         static void CreateMemberCalls()
         {
             var csharpArgumentInfoType = Type.GetType(CSharpArgumentInfoTypeName, true)!;
@@ -73,6 +78,8 @@ static class DynamicUtils
             setMemberCall = DelegateFactory.CreateMethodCall<object?>(setMemberMethod);
         }
 
+        [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+        [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
         public static CallSiteBinder GetMember(string name, Type context)
         {
             Init();
@@ -81,6 +88,8 @@ static class DynamicUtils
             return (CallSiteBinder) getMemberCall(null, 0, name, context, getCSharpArgumentInfoArray)!;
         }
 
+        [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+        [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
         public static CallSiteBinder SetMember(string name, Type context)
         {
             Init();
@@ -97,6 +106,7 @@ static class DynamicUtils
     }
 }
 
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 class NoThrowGetBinderMember(GetMemberBinder innerBinder) :
     GetMemberBinder(innerBinder.Name, innerBinder.IgnoreCase)
 {
@@ -111,6 +121,7 @@ class NoThrowGetBinderMember(GetMemberBinder innerBinder) :
     }
 }
 
+[RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
 class NoThrowSetBinderMember(SetMemberBinder innerBinder) :
     SetMemberBinder(innerBinder.Name, innerBinder.IgnoreCase)
 {

--- a/src/Argon/Utilities/EnumUtils.cs
+++ b/src/Argon/Utilities/EnumUtils.cs
@@ -9,6 +9,7 @@ static class EnumUtils
 
     static readonly ThreadSafeStore<Tuple<Type, NamingStrategy?>, EnumInfo> ValuesAndNamesPerEnum = new(InitializeValuesAndNames);
 
+    [UnconditionalSuppressMessage("TrimAnalysis", "IL2075", Justification = "Enum fields are not trimmed")]
     static EnumInfo InitializeValuesAndNames(Tuple<Type, NamingStrategy?> key)
     {
         var enumType = key.Item1;

--- a/src/Argon/Utilities/ImmutableCollectionsUtils.cs
+++ b/src/Argon/Utilities/ImmutableCollectionsUtils.cs
@@ -78,6 +78,8 @@ static class ImmutableCollectionsUtils
             .ToFrozenDictionary();
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     internal static bool TryBuildImmutableForArrayContract(Type targetType, Type collectionItemType, [NotNullWhen(true)] out Type? createdType, [NotNullWhen(true)] out ObjectConstructor? parameterizedCreator)
     {
         if (targetType.IsGenericType &&
@@ -95,13 +97,16 @@ static class ImmutableCollectionsUtils
         return false;
     }
 
-    static MethodInfo GetArrayCreateRange(Type type) =>
+    static MethodInfo GetArrayCreateRange(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods )] Type type) =>
         type
             .GetMethods()
             .Single(_ => _.Name == "CreateRange" &&
                          _.GetParameters()
                              .Length == 1);
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
     internal static bool TryBuildImmutableForDictionaryContract(Type targetType, Type keyItemType, Type valueItemType, [NotNullWhen(true)] out Type? createdType, [NotNullWhen(true)] out ObjectConstructor? parameterizedCreator)
     {
         if (targetType.IsGenericType &&
@@ -118,7 +123,8 @@ static class ImmutableCollectionsUtils
         return false;
     }
 
-    static MethodInfo GetDictionaryCreateRange(Type type) =>
+    static MethodInfo GetDictionaryCreateRange(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods )] Type type) =>
         type
             .GetMethods()
             .Single(_ =>

--- a/src/Argon/Utilities/MiscellaneousUtils.cs
+++ b/src/Argon/Utilities/MiscellaneousUtils.cs
@@ -8,6 +8,10 @@
 
 static class MiscellaneousUtils
 {
+    internal const string TrimWarning = "Argon relies on reflection over types that may be removed when trimming.";
+
+    internal const string AotWarning = "Argon relies on dynamically creating types that may not be available with Ahead of Time compilation.";
+
     [Conditional("DEBUG")]
     public static void Assert([DoesNotReturnIf(false)] bool condition, string? message = null) =>
         Debug.Assert(condition, message);

--- a/src/Argon/Utilities/ReflectionObject.cs
+++ b/src/Argon/Utilities/ReflectionObject.cs
@@ -22,7 +22,17 @@ class ReflectionObject
     public Type GetType(string member) =>
         Members[member].MemberType!;
 
-    public static ReflectionObject Create(Type type, MethodBase? creator, params string[] memberNames)
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
+    public static ReflectionObject Create(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.NonPublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicConstructors |
+            DynamicallyAccessedMemberTypes.PublicEvents |
+            DynamicallyAccessedMemberTypes.PublicFields |
+            DynamicallyAccessedMemberTypes.PublicMethods |
+            DynamicallyAccessedMemberTypes.PublicNestedTypes |
+            DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type type, MethodBase? creator, params string[] memberNames)
     {
         var creatorConstructor = CreatorConstructor(type, creator);
 
@@ -73,7 +83,11 @@ class ReflectionObject
         return new(creatorConstructor, memberLookup.ToFrozenDictionary());
     }
 
-    static ObjectConstructor? CreatorConstructor(Type type, MethodBase? creator)
+    [RequiresDynamicCode(MiscellaneousUtils.AotWarning)]
+    static ObjectConstructor? CreatorConstructor(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        Type type,
+        MethodBase? creator)
     {
         if (creator == null)
         {

--- a/src/Argon/Utilities/ReflectionUtils.cs
+++ b/src/Argon/Utilities/ReflectionUtils.cs
@@ -127,7 +127,8 @@ static class ReflectionUtils
         return builder.ToString();
     }
 
-    public static bool HasDefaultConstructor(this Type type)
+    public static bool HasDefaultConstructor(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.None | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type)
     {
         if (type.IsValueType)
         {
@@ -137,7 +138,9 @@ static class ReflectionUtils
         return GetDefaultConstructor(type, false) != null;
     }
 
-    public static ConstructorInfo? GetDefaultConstructor(this Type type, bool nonPublic)
+    public static ConstructorInfo? GetDefaultConstructor(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.None | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] this Type type,
+        bool nonPublic)
     {
         var bindingFlags = BindingFlags.Instance | BindingFlags.Public;
         if (nonPublic)
@@ -180,10 +183,15 @@ static class ReflectionUtils
         type.IsGenericType &&
         type.GetGenericTypeDefinition() == genericInterfaceDefinition;
 
-    public static bool ImplementsGeneric(this Type type, Type genericInterfaceDefinition) =>
+    public static bool ImplementsGeneric(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type,
+        Type genericInterfaceDefinition) =>
         type.ImplementsGeneric(genericInterfaceDefinition, out _);
 
-    public static bool ImplementsGeneric(this Type type, Type genericInterfaceDefinition, [NotNullWhen(true)] out Type? implementingType)
+    public static bool ImplementsGeneric(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type,
+        Type genericInterfaceDefinition,
+        [NotNullWhen(true)] out Type? implementingType)
     {
         if (!genericInterfaceDefinition.IsInterface ||
             !genericInterfaceDefinition.IsGenericTypeDefinition)
@@ -256,7 +264,8 @@ static class ReflectionUtils
     /// </summary>
     /// <param name="type">The type.</param>
     /// <returns>The type of the typed collection's items.</returns>
-    public static Type? GetCollectionItemType(this Type type)
+    public static Type? GetCollectionItemType(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] this Type type)
     {
         if (type.IsArray)
         {
@@ -281,7 +290,10 @@ static class ReflectionUtils
         throw new($"Type {type} is not a collection.");
     }
 
-    public static void GetDictionaryKeyValueTypes(this Type dictionaryType, out Type? keyType, out Type? valueType)
+    public static void GetDictionaryKeyValueTypes([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+        this Type dictionaryType,
+        out Type? keyType,
+        out Type? valueType)
     {
         if (dictionaryType.ImplementsGeneric(typeof(IDictionary<,>), out var genericDictionaryType))
         {
@@ -423,6 +435,7 @@ static class ReflectionUtils
         return false;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
     public static List<MemberInfo> GetFieldsAndProperties(this Type type, BindingFlags bindingFlags) =>
         [
         ..GetFields(type, bindingFlags),
@@ -473,7 +486,22 @@ static class ReflectionUtils
         return null;
     }
 
-    public static MemberInfo? GetMemberInfoFromType(Type targetType, MemberInfo member)
+    public static MemberInfo? GetMemberInfoFromType(
+        [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.NonPublicConstructors |
+        DynamicallyAccessedMemberTypes.NonPublicEvents |
+        DynamicallyAccessedMemberTypes.NonPublicFields |
+        DynamicallyAccessedMemberTypes.NonPublicMethods |
+        DynamicallyAccessedMemberTypes.NonPublicNestedTypes |
+        DynamicallyAccessedMemberTypes.NonPublicProperties |
+        DynamicallyAccessedMemberTypes.PublicConstructors |
+        DynamicallyAccessedMemberTypes.PublicEvents |
+        DynamicallyAccessedMemberTypes.PublicFields |
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.PublicNestedTypes |
+        DynamicallyAccessedMemberTypes.PublicProperties)]
+        Type targetType,
+        MemberInfo member)
     {
         const BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
@@ -495,7 +523,10 @@ static class ReflectionUtils
         return targetType.GetMember(member.Name, memberType, bindingFlags).SingleOrDefault();
     }
 
-    static List<FieldInfo> GetFields(Type targetType, BindingFlags bindingFlags)
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    static List<FieldInfo> GetFields(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.None | DynamicallyAccessedMemberTypes.PublicFields)] Type targetType,
+        BindingFlags bindingFlags)
     {
         var fields = new List<FieldInfo>(targetType.GetFields(bindingFlags));
         // Type.GetFields doesn't return inherited private fields
@@ -505,6 +536,7 @@ static class ReflectionUtils
         return fields;
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
     static void GetChildPrivateFields(List<FieldInfo> initialFields, Type targetType, BindingFlags bindingFlags)
     {
         // fix weirdness with private FieldInfos only being returned for the current Type
@@ -527,6 +559,7 @@ static class ReflectionUtils
         }
     }
 
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
     static List<PropertyInfo> GetProperties(Type targetType, BindingFlags bindingFlags)
     {
         var properties = new List<PropertyInfo>(targetType.GetProperties(bindingFlags));
@@ -560,7 +593,10 @@ static class ReflectionUtils
             ? source ^ flag
             : source;
 
-    static void GetChildPrivateProperties(List<PropertyInfo> initialProperties, Type targetType, BindingFlags bindingFlags)
+    [RequiresUnreferencedCode(MiscellaneousUtils.TrimWarning)]
+    static void GetChildPrivateProperties(List<PropertyInfo> initialProperties,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)] Type targetType,
+        BindingFlags bindingFlags)
     {
         // fix weirdness with private PropertyInfos only being returned for the current Type
         // find base type properties and add them to result
@@ -627,7 +663,10 @@ static class ReflectionUtils
         }
     }
 
-    public static bool IsMethodOverridden(Type currentType, Type methodDeclaringType, string method)
+    public static bool IsMethodOverridden(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] Type currentType,
+        Type methodDeclaringType,
+        string method)
     {
         foreach (var inner in currentType
                      .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
@@ -645,7 +684,8 @@ static class ReflectionUtils
         return false;
     }
 
-    public static object? GetDefaultValue(Type type)
+    public static object? GetDefaultValue(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
     {
         if (!type.IsValueType)
         {


### PR DESCRIPTION
## Motivation

I wanted to test out whether the Verify project could be used when compiled for NativeAot. As a first step, I decided to annotate the json serializer regarding trimming and aot.

Unfortunately, I did not easily achieve AOT compatibility for the Verify project, so I gave up, but maybe these annotations can benefit something else.


-> Based on https://github.com/JamesNK/Newtonsoft.Json/pull/2980